### PR TITLE
Custom Validator Option

### DIFF
--- a/core/components/recaptchav2/elements/snippets/recaptchav2.snippet.php
+++ b/core/components/recaptchav2/elements/snippets/recaptchav2.snippet.php
@@ -64,17 +64,40 @@ if (!($recaptchav2 instanceof \ReCaptcha\ReCaptcha)) {
 $resp = null;
 // The error code from reCAPTCHA, if any
 $error = null;
-
+// Check if being used as hook
+if (isset($hook)){
 // Was there a reCAPTCHA response?
-if ($hook->getValue('g-recaptcha-response')) {
-    $resp = $recaptchav2->verify($hook->getValue('g-recaptcha-response'), $_SERVER["REMOTE_ADDR"]);
-}
+    if ($hook->getValue('g-recaptcha-response')) {
+        $resp = $recaptchav2->verify($hook->getValue('g-recaptcha-response'), $_SERVER["REMOTE_ADDR"]);
+    }
 
 // Hook pass/fail
-if ($resp != null && $resp->isSuccess()) {
-    return true;
-} else {
-    $hook->addError('recaptchav2_error', $recaptcha_err_msg);
-    //DEBUG INFO: $modx->log(modX::LOG_LEVEL_ERROR, print_r($resp, true));
-    return false;
+    if ($resp != null && $resp->isSuccess()) {
+        return true;
+    } else {
+        $hook->addError('recaptchav2_error', $recaptcha_err_msg);
+        $modx->log(modX::LOG_LEVEL_DEBUG, print_r($resp, true));
+        return false;
+    }
 }
+// Check if being used as validator
+if (isset($validator)) {
+// Was there a reCAPTCHA response?
+    if (isset($value)) {
+        $resp = $recaptchav2->verify($value, $_SERVER["REMOTE_ADDR"]);
+    }
+
+// Validator pass/fail
+    if ($resp != null && $resp->isSuccess()) {
+        return true;
+    } else {
+        $validator->addError($key, $recaptcha_err_msg);
+        $modx->log(modX::LOG_LEVEL_DEBUG, print_r($resp, true));
+        return $success;
+    }
+
+
+}
+
+// Checks failed
+return false;


### PR DESCRIPTION
This adds the ability to set it as a customValidator instead of a hook if wanted. The hook method fires after everything else is validated, the customValidator method fires during the validation process of the rest of the form fields.  To use set

```
&customValidators=`recaptchav2`
&validate=`g-recaptcha-response:recaptchav2`
```

This is an optional alteration that helps people identify if their reCaptcha is failing for them sooner in the completion process.