### PR TITLE
Invisible captcha option

### DIFF
--- a/core/components/recaptchav2/elements/chunks/recaptchav2_html.chunk.tpl
+++ b/core/components/recaptchav2/elements/chunks/recaptchav2_html.chunk.tpl
@@ -1,2 +1,2 @@
 <div class="g-recaptcha" data-sitekey="[[+site_key]]"></div>
-<script type="text/javascript" src="https://www.google.com/recaptcha/api.js?hl=[[++cultureKey]]"></script>
+<script type="text/javascript" src="https://www.google.com/recaptcha/api.js?hl=[[+lang]]"></script>

--- a/core/components/recaptchav2/elements/chunks/recaptchav2_invisible.chunk.tpl
+++ b/core/components/recaptchav2/elements/chunks/recaptchav2_invisible.chunk.tpl
@@ -1,12 +1,11 @@
 <script type="text/javascript" >
-    function onSubmit(token) {
-        return true;
-    }
-    var onloadCallback = function() {
-        grecaptcha.render('submit', {
-            'sitekey' : '[[++site_key]]',
-            'callback' : onSubmit
+    function onloadCallback() {
+        grecaptcha.render('[[+submitVar]]', {
+            'sitekey' : '[[+site_key]]',
+            'callback' : function (token) {
+                document.getElementById('[[+submitVar]]').closest('form').submit();
+            }
         });
-    };
+    }
 </script>
-<script type="text/javascript" src="https://www.google.com/recaptcha/api.js?onload=onloadCallback&render=explicit&hl=[[++cultureKey]]" async defer ></script>
+<script type="text/javascript" src="https://www.google.com/recaptcha/api.js?onload=onloadCallback&render=explicit&hl=[[+lang]]" async defer ></script>

--- a/core/components/recaptchav2/elements/chunks/recaptchav2_invisible.chunk.tpl
+++ b/core/components/recaptchav2/elements/chunks/recaptchav2_invisible.chunk.tpl
@@ -1,0 +1,12 @@
+<script type="text/javascript" >
+    function onSubmit(token) {
+        return true;
+    }
+    var onloadCallback = function() {
+        grecaptcha.render('submit', {
+            'sitekey' : '[[++site_key]]',
+            'callback' : onSubmit
+        });
+    };
+</script>
+<script type="text/javascript" src="https://www.google.com/recaptcha/api.js?onload=onloadCallback&render=explicit&hl=[[++cultureKey]]" async defer ></script>

--- a/core/components/recaptchav2/elements/snippets/recaptchav2_render.snippet.php
+++ b/core/components/recaptchav2/elements/snippets/recaptchav2_render.snippet.php
@@ -29,16 +29,21 @@
  */
 
 // Register API keys at https://www.google.com/recaptcha/admin
-$site_key = $modx->getOption('recaptchav2.site_key', null, '');
+$site_key = $modx->getOption('recaptchav2.site_key', $scriptProperties, '');
 // reCAPTCHA supported 40+ languages listed here: https://developers.google.com/recaptcha/docs/language
-$lang = $modx->getOption('cultureKey', null, 'en');
+$lang = $modx->getOption('cultureKey', $scriptProperties, 'en');
+// Choose ReCaptcha TPL
+$tpl = $modx->getOption('tpl', $scriptProperties, 'recaptchav2_html');
+// Set the submitVar
+$submitVar = $modx->getOption('submitVar', $scriptProperties, 'submit');
 
-$recaptcha_html = $modx->getChunk('recaptchav2_html', array(
+$recaptcha_html = $modx->getChunk($tpl, array(
     'site_key' => $site_key,
     'lang' => $lang,
-    ));
+    'submitVar' => $submitVar
+));
 
-if ($hook) { 
+if ($hook) {
     $hook->setValue('recaptchav2_html', $recaptcha_html); // This won't re-render on page reload there's validation errors
     return true;
 } else { // This works at least


### PR DESCRIPTION
I'm going to submit this as is, it basically just adds the ability to template the recaptcha box by setting `tpl`, `culstureKey` and `submitVar` to be swappable in the snippet call.  It also provides an example TPL for invisible captcha.  The invisible captcha would need to be updated if there were multiple forms on a page, but the implementation method would be site specific. 