### PR TITLE
Allow captioning of submit button

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ As of 2.3+, you can use the "Invisible Recaptcha" implementation:
 [[!recaptchav2_render?
     &tpl=`recaptchav2_invisible_html`
     &form_id=`login-form`
+    &button_caption=`Submit this form`
 ]]
 </form>
 ```

--- a/core/components/recaptchav2/elements/chunks/recaptchav2_invisible_html.chunk.tpl
+++ b/core/components/recaptchav2/elements/chunks/recaptchav2_invisible_html.chunk.tpl
@@ -1,3 +1,3 @@
 <script type="text/javascript" src="https://www.google.com/recaptcha/api.js?hl=[[++cultureKey]]"></script>
 <script>function recaptchaV2SubmitForm() { document.getElementById('[[+form_id]]').submit(); }</script>
-<button type="submit" class="g-recaptcha" name="Login" data-sitekey="[[+site_key]]" data-callback="recaptchaV2SubmitForm">Login</button>
+<button type="submit" class="g-recaptcha" name="Login" data-sitekey="[[+site_key]]" data-callback="recaptchaV2SubmitForm">[[+button_caption]]</button>

--- a/core/components/recaptchav2/elements/snippets/recaptchav2_render.snippet.php
+++ b/core/components/recaptchav2/elements/snippets/recaptchav2_render.snippet.php
@@ -35,11 +35,13 @@ $lang = $modx->getOption('cultureKey', null, 'en', true);
 // use 'recaptchav2_invisible_html' inside form element for invisible recaptcha
 $tpl = $modx->getOption('tpl', $scriptProperties, 'recaptchav2_html', true);
 $form_id = $modx->getOption('form_id', $scriptProperties, '');
+$button_caption = $modx->getOption('button_caption', $scriptProperties, 'Login');
 
 $recaptcha_html = $modx->getChunk($tpl, array(
     'site_key' => $site_key,
     'lang' => $lang,
     'form_id' => $form_id,
+    'button_caption' => $button_caption,
     ));
 
 if ($hook) { 


### PR DESCRIPTION
Addition of a button_caption parameter which is passed through to caption the submit button generated by the invisible captcha.