### PR TITLE
Clientside fix for timeout-or-duplicate error

### DIFF
--- a/core/components/recaptchav2/elements/chunks/recaptchav3_html.chunk.tpl
+++ b/core/components/recaptchav2/elements/chunks/recaptchav3_html.chunk.tpl
@@ -2,9 +2,13 @@
 <input type="hidden" name="[[+token_key]]">
 <input type="hidden" name="[[+action_key]]" value="[[+form_id]]">
 <script>
+function getReCaptcha[[+form_id]](){ 
     grecaptcha.ready(function() {
         grecaptcha.execute('[[+site_key]]', {action: '[[+form_id]]'}).then(function(token) {
             document.querySelector('[name="[[+token_key]]"]').value = token;
         });
     });
+}
+getReCaptcha[[+form_id]](); 
+setInterval(function(){ getReCaptcha[[+form_id]](); }, 2 * 60 * 1000);      
 </script>


### PR DESCRIPTION
When someone submits a form and takes longer then 2 minutes (after entering a webpage) they get an error "timeout-or-duplicate". This error comes from the Google reCaptcha v3 token verification.

There is a topic on Stackoverflow
https://stackoverflow.com/questions/55251837/how-to-solve-google-v3-recaptcha-timeout

In order to solve this error we bypass it by changing recaptchav3_html.chunk.tpl. This forces a refresh every 2 minutes.
If you have several forms we use the [[+form_id]] to refresh every form.